### PR TITLE
Add dataset translation through ckan CLI

### DIFF
--- a/ckanext/harvest/cli.py
+++ b/ckanext/harvest/cli.py
@@ -234,11 +234,18 @@ def purge_queues():
 
 
 @harvester.command()
-def gather_consumer():
+@click.option(
+    "-t",
+    "--translate",
+    default=None,
+    help="""Translate dataset content to a specific language.
+    Language code is ISO 639-1 which is the alpha-2 code""",
+)
+def gather_consumer(translate_lang):
     """Starts the consumer for the gathering queue.
 
     """
-    utils.gather_consumer()
+    utils.gather_consumer(translate_lang)
 
 
 @harvester.command()

--- a/ckanext/harvest/commands/harvester.py
+++ b/ckanext/harvest/commands/harvester.py
@@ -240,7 +240,10 @@ class Harvester(CkanCommand):
         elif cmd == "run_test":
             self.run_test_harvest()
         elif cmd == "gather_consumer":
-            utils.gather_consumer()
+            translate_lang = None
+            if len(self.args) >= 2:
+                translate_lang = unicode_safe(self.args[1])
+            utils.gather_consumer(translate_lang)
         elif cmd == "fetch_consumer":
             utils.fetch_consumer()
         elif cmd == "purge_queues":

--- a/ckanext/harvest/harvesters/ckanharvester.py
+++ b/ckanext/harvest/harvesters/ckanharvester.py
@@ -266,6 +266,11 @@ class CKANHarvester(HarvesterBase):
 
         # Create harvest objects for each dataset
         try:
+            # Initialize translator
+            log.debug('Translation language: %s', harvest_job.translate_lang)
+            if harvest_job.translate_lang:
+                self.init_translate(harvest_job.translate_lang)
+
             package_ids = set()
             object_ids = []
             for pkg_dict in pkg_dicts:
@@ -276,6 +281,8 @@ class CKANHarvester(HarvesterBase):
                              pkg_dict['id'])
                     continue
                 package_ids.add(pkg_dict['id'])
+                if harvest_job.translate_lang:
+                    self.translate_pakage(pkg_dict)
 
                 log.debug('Creating HarvestObject for %s %s',
                           pkg_dict['name'], pkg_dict['id'])

--- a/ckanext/harvest/queue.py
+++ b/ckanext/harvest/queue.py
@@ -336,7 +336,7 @@ def get_consumer(queue_name, routing_key):
         return RedisConsumer(connection, routing_key)
 
 
-def gather_callback(channel, method, header, body):
+def gather_callback(channel, method, header, body, translate_lang):
 
     try:
         id = json.loads(body)['harvest_job_id']
@@ -371,6 +371,7 @@ def gather_callback(channel, method, header, body):
     harvester = get_harvester(job.source.type)
     if harvester:
         try:
+            job.translate_lang = translate_lang
             harvest_object_ids = gather_stage(harvester, job)
         except (Exception, KeyboardInterrupt):
             channel.basic_ack(method.delivery_tag)

--- a/ckanext/harvest/utils.py
+++ b/ckanext/harvest/utils.py
@@ -325,7 +325,7 @@ def abort_job(job_or_source_id_or_name):
     return "Job status: {0}".format(job["status"])
 
 
-def gather_consumer():
+def gather_consumer(translate_lang):
     import logging
     from ckanext.harvest.queue import (
         get_gather_consumer,
@@ -337,7 +337,7 @@ def gather_consumer():
     consumer = get_gather_consumer()
     for method, header, body in consumer.consume(
             queue=get_gather_queue_name()):
-        gather_callback(consumer, method, header, body)
+        gather_callback(consumer, method, header, body, translate_lang)
 
 
 def fetch_consumer():

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ enum34; python_version < '3.0'  # Required by pika
 redis
 requests>=2.11.1
 six>=1.12.0
+deep-translator>=1.8.3


### PR DESCRIPTION
This feature uses Google translate free plan through deep-translator library: https://github.com/nidhaloff/deep-translator

Translation can be triggered during harvesting with "-t/--translate language" argument, where language code is ISO 639-1 which is the alpha-2 code.

Example:
ckan --config=/etc/ckan/default/ckan.ini harvester gather-consumer -t fr